### PR TITLE
Drop index to allow for siteId column to be dropped

### DIFF
--- a/src/migrations/m220104_164702_simplify_cache_strategy.php
+++ b/src/migrations/m220104_164702_simplify_cache_strategy.php
@@ -10,6 +10,12 @@ class m220104_164702_simplify_cache_strategy extends Migration
     public function safeUp()
     {
         $table = ElementRelationsRecord::tableName();
+        // drop previous index on 'siteId` which was built by the install so we can drop the column
+        foreach (Craft::$app->db->getSchema()->findIndexes($table) as $name => $index) {
+            if ($index['columns'] === ['siteId']) {
+                $this->dropIndex($name, $table);
+            }
+        }
         $this->dropColumn($table, 'siteId');
         $this->dropColumn($table, 'markup');
         $this->createIndex(null, $table, ['relations', 'dateUpdated']);


### PR DESCRIPTION
This provides a fix for #6 since the error state shows an index which must be dropped before the column can be