### PR TITLE
Changes to ensure clean siteId column drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.5 - 2022-02-04
+### Fixed
+- Better fix for [#6](https://github.com/internetztube/craft-element-relations/issues/6) Safely dropping foreign keys and index on `siteId` and `markup` columns.
+
 ## 1.2.4 - 2022-02-02
 ### Fixed
-- Fixed #6.
+- Fixed [#6](https://github.com/internetztube/craft-element-relations/issues/6).
 
 ## 1.2.3 - 2022-01-07
 ### Added

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -22,7 +22,12 @@ class Install extends Migration
             ]);
 
             $this->createIndex(null, $table, ['elementId'], true);
-            $this->createIndex(null, $table, ['relations', 'dateUpdated']);
+            // Adding an index on a text field in mysql requires a length
+            if (Craft::$app->db->getIsMysql()) {
+                $this->createIndex(null, $table, ['relations(250)', 'dateUpdated']);
+            } else {
+                $this->createIndex(null, $table, ['relations', 'dateUpdated']);
+            }
             $this->addForeignKey(null, $table, 'elementId', '{{%elements}}', 'id', 'CASCADE');
 
             // Refresh the db schema caches

--- a/src/migrations/m220104_164702_simplify_cache_strategy.php
+++ b/src/migrations/m220104_164702_simplify_cache_strategy.php
@@ -2,6 +2,7 @@
 
 namespace internetztube\elementRelations\migrations;
 
+use Craft;
 use craft\db\Migration;
 use internetztube\elementRelations\records\ElementRelationsRecord;
 
@@ -10,21 +11,38 @@ class m220104_164702_simplify_cache_strategy extends Migration
     public function safeUp()
     {
         $table = ElementRelationsRecord::tableName();
+        // drop previous foreign key on 'siteId` which was built by the install so we can drop the column
+        foreach (Craft::$app->db->getSchema()->getTableForeignKeys($table) as $foreignKey) {
+            if (in_array('siteId',$foreignKey->columnNames)) {
+                $keyName = $foreignKey->name;
+                $this->dropForeignKey($foreignKey->name, $table);
+            }
+        }
+
         // drop previous index on 'siteId` which was built by the install so we can drop the column
         foreach (Craft::$app->db->getSchema()->findIndexes($table) as $name => $index) {
             if ($index['columns'] === ['siteId']) {
                 $this->dropIndex($name, $table);
             }
         }
-        $this->dropColumn($table, 'siteId');
-        $this->dropColumn($table, 'markup');
-        $this->createIndex(null, $table, ['relations', 'dateUpdated']);
+        if (Craft::$app->db->columnExists($table, 'siteId')) {
+            $this->dropColumn($table, 'siteId');
+        }
+        if (Craft::$app->db->columnExists($table, 'markup')) {
+            $this->dropColumn($table, 'markup');
+        }
+        // Adding an index on a text field in mysql requires a length
+        if (Craft::$app->db->getIsMysql()) {
+            $this->createIndex(null, $table, ['relations(250)', 'dateUpdated']);
+        } else {
+            $this->createIndex(null, $table, ['relations', 'dateUpdated']);
+        }
         return true;
     }
 
     public function safeDown()
     {
-        echo "m220104_132645_simplify_cache_strategy cannot be reverted.\n";
+        echo "m220104_164702_simplify_cache_strategy cannot be reverted.\n";
         return false;
     }
 }


### PR DESCRIPTION
When I applied my changes in the previous PR, things worked, but I need to make a few changes so it would work from a clean install and on another server where the migration had stopped halfway. This safely drops the foreign key implicitly created by the index, the index itself, and then the columns if they exist.

Also, the index on `relations` and `dateUpdated` was throwing an error for MySQL users [MySQL Error 1170](https://techjourney.net/mysql-error-1170-42000-blobtext-column-used-in-key-specification-without-a-key-length/) because an index on a text field needs a length. This seems to have handled it, but I'd love a second set of 👀 to make sure that's functioning as designed for others.