### PR TITLE
Bug Fix: Providing default values for siteId when it's not returned from the query properly

### DIFF
--- a/src/services/ElementRelationsService.php
+++ b/src/services/ElementRelationsService.php
@@ -311,11 +311,11 @@ class ElementRelationsService
         return collect($queryResults)
             ->merge($mainQuery->all())
             ->map(function (array $row) {
-                $element = ElementRelationsService::getElementById($row['id'], $row['siteId'] ?? $rootElement->siteId);
+                $element = ElementRelationsService::getElementById($row['id'], $row['siteId']);
                 if (!$element) {
                     return null;
                 }
-                $rootElement = ElementRelationsService::getRootElement($element, $row['siteId'] ?? $rootElement->siteId);
+                $rootElement = ElementRelationsService::getRootElement($element, $row['siteId']);
                 if (!$rootElement) {
                     return null;
                 }

--- a/src/services/ElementRelationsService.php
+++ b/src/services/ElementRelationsService.php
@@ -311,11 +311,11 @@ class ElementRelationsService
         return collect($queryResults)
             ->merge($mainQuery->all())
             ->map(function (array $row) {
-                $element = ElementRelationsService::getElementById($row['id'], $row['siteId']);
+                $element = ElementRelationsService::getElementById($row['id'], $row['siteId'] ?? $rootElement->siteId);
                 if (!$element) {
                     return null;
                 }
-                $rootElement = ElementRelationsService::getRootElement($element, $row['siteId']);
+                $rootElement = ElementRelationsService::getRootElement($element, $row['siteId'] ?? $rootElement->siteId);
                 if (!$rootElement) {
                     return null;
                 }

--- a/src/services/ElementRelationsService.php
+++ b/src/services/ElementRelationsService.php
@@ -311,11 +311,11 @@ class ElementRelationsService
         return collect($queryResults)
             ->merge($mainQuery->all())
             ->map(function (array $row) {
-                $element = ElementRelationsService::getElementById($row['id'], $row['siteId']);
+                $element = ElementRelationsService::getElementById($row['id'], $row['siteId'] ?? 1);
                 if (!$element) {
                     return null;
                 }
-                $rootElement = ElementRelationsService::getRootElement($element, $row['siteId']);
+                $rootElement = ElementRelationsService::getRootElement($element, $row['siteId'] ?? 1);
                 if (!$rootElement) {
                     return null;
                 }


### PR DESCRIPTION
This seems to fix #27 for me, and I'm able to reproduce it by undoing the change and refreshing the item. 