### PR TITLE
Fix error , if entry doesn't exist in primary site

### DIFF
--- a/src/services/MarkupService.php
+++ b/src/services/MarkupService.php
@@ -20,7 +20,7 @@ class MarkupService
      */
     public static function getMarkupFromElementRelations(string $elementRelations, int $elementId, int $siteId, string $size = 'small'): string
     {
-        $element = Craft::$app->elements->getElementById($elementId);
+        $element = Craft::$app->elements->getElementById($elementId, null, $siteId);
         $supportedSiteIds = $element->getSupportedSites();
         $allSiteIds = Craft::$app->sites->getAllSiteIds();
         $currentAndNotSupportedSites = collect($allSiteIds)->filter(function (int $allSiteId) use ($siteId, $allSiteIds, $supportedSiteIds) {


### PR DESCRIPTION
If an entry does not exist in the primary site (e.g. only in a second site), the request for the element requests with the wrong siteId (the siteId from the primary site). The request should also have the current siteId.