### PR TITLE
Fix: if only simple and no element relation found

### DIFF
--- a/src/controllers/ElementRelationsController.php
+++ b/src/controllers/ElementRelationsController.php
@@ -25,14 +25,16 @@ class ElementRelationsController extends Controller
         $result = $markup;
         if (CacheService::useCache()) {
             $dateUpdated = CacheService::getDateUpdatedFromElementRelations($elementId);
-            $dateUpdated = DateTimeHelper::toDateTime($dateUpdated)
-                ->setTimezone(new \DateTimeZone(Craft::$app->getTimeZone()))
-                ->format(Craft::$app->getFormattingLocale()->getDateTimeFormat(Locale::LENGTH_LONG, Locale::FORMAT_PHP));
-            $markupDate = sprintf('<span class="info element-relations-lazy-hidden">%s %s</span>', Craft::t('element-relations', 'field-value-last-update'), $dateUpdated);
-            $markupReloadButton = sprintf('<button type="button" class="btn small js-element-relations-reload element-relations-lazy-hidden">%s</button>', Craft::t('element-relations', 'field-value-button-reload'));
-            $markupRefreshButton = sprintf('<button type="button" class="btn small js-element-relations-refresh element-relations-lazy-hidden">%s</button>', Craft::t('element-relations', 'field-value-button-refresh'));
-            $style = '<style>.element-relations-lazy-hidden { display: none; }</style>';
-            $result .= '<br />' . $markupReloadButton . ' ' . $markupRefreshButton . ' ' . $markupDate . ' ' . $style;
+            if (!is_null($dateUpdated)) {
+                $dateUpdated = DateTimeHelper::toDateTime($dateUpdated)
+                    ->setTimezone(new \DateTimeZone(Craft::$app->getTimeZone()))
+                    ->format(Craft::$app->getFormattingLocale()->getDateTimeFormat(Locale::LENGTH_LONG, Locale::FORMAT_PHP));
+                $markupDate = sprintf('<span class="info element-relations-lazy-hidden">%s %s</span>', Craft::t('element-relations', 'field-value-last-update'), $dateUpdated);
+                $markupReloadButton = sprintf('<button type="button" class="btn small js-element-relations-reload element-relations-lazy-hidden">%s</button>', Craft::t('element-relations', 'field-value-button-reload'));
+                $markupRefreshButton = sprintf('<button type="button" class="btn small js-element-relations-refresh element-relations-lazy-hidden">%s</button>', Craft::t('element-relations', 'field-value-button-refresh'));
+                $style = '<style>.element-relations-lazy-hidden { display: none; }</style>';
+                $result .= '<br />' . $markupReloadButton . ' ' . $markupRefreshButton . ' ' . $markupDate . ' ' . $style;
+            }
         }
         return $result;
     }


### PR DESCRIPTION
The pull request fix the problem, if we have only a simple relation in "relations" table, but no entry in "element_relations" table. The value $elementRelations (line 23) has a value !="|", but $dateUpdated is null, because CacheService::getDateUpdatedFromElementRelations only shows in the element_relations table.

The problem only occurs, if you have an entry, that is not present in the default site group.