### PR TITLE
Add table indexes to improve read performance

### DIFF
--- a/src/migrations/m241004_144031_optimize_index_elementrelations_table.php
+++ b/src/migrations/m241004_144031_optimize_index_elementrelations_table.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace internetztube\elementRelations\migrations;
+
+use Craft;
+use craft\db\Migration;
+use internetztube\elementRelations\records\ElementRelationsCacheRecord;
+
+/**
+ * m241004_144031_optimize_index_elementrelations_table migration.
+ */
+class m241004_144031_optimize_index_elementrelations_table extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        foreach ($this->_indexes() as $index) {
+            $this->createIndexIfMissing(...$index);
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        foreach ($this->_indexes() as $index) {
+            $this->dropIndexIfExists(...$index);
+        }
+        return true;
+    }
+
+    private function _indexes(): array
+    {
+        return [
+            [ElementRelationsCacheRecord::tableName(), ['sourceElementId', 'sourceSiteId'], false],
+            [ElementRelationsCacheRecord::tableName(), ['targetElementId', 'targetSiteId'], false],
+            [ElementRelationsCacheRecord::tableName(), ['sourcePrimaryOwnerId'], false],
+        ];
+    }
+}


### PR DESCRIPTION
This is a small performance improvement to speed up [reading](https://github.com/internetztube/craft-element-relations/blob/75a6101214fd40e146ddfa22d85b786dc8c0809d/src/services/RelationsService.php#L24-L35) and [deleting](https://github.com/internetztube/craft-element-relations/blob/75a6101214fd40e146ddfa22d85b786dc8c0809d/src/services/ExtractorService.php#L70-L73) query operations, to improve performance.