### PR TITLE
Display section names next to related elements in relations field

### DIFF
--- a/src/templates/_components/fields/relations.twig
+++ b/src/templates/_components/fields/relations.twig
@@ -17,7 +17,13 @@
         {% endif %}
         {% for relation in relations %}
             <tr>
-                <td>{{ elementRelationsElementPreviewHtml([relation]) | raw }}</td>
+                <td style="white-space: nowrap;">
+                    <span style="display: inline-block;">{{ elementRelationsElementPreviewHtml([relation]) | raw }}</span>
+                    {# Add belonging section name to relationship entry. #}
+                    {% if relation.section is defined %}
+                        <span style="color: #666; font-weight: normal; margin-left: 4px;">({{ relation.section.name }})</span>
+                    {% endif %}
+                </td>
                 <td>
                     {% if relation.url %}
                         <a href="{{ relation.url }}" title="Visit webpage" rel="noopener" target="_blank"


### PR DESCRIPTION
This PR enhances the relations field display by showing the section name inline with each related element, improving content organization and reducing visual clutter.
Changes Made

- Modified relations.twig template to display section names inline with element titles
- Added styling to prevent line breaks and ensure proper spacing
- Section names appear in lighter gray text with format: "Element Title (Section Name)"
- Added proper null checks to handle non-entry elements gracefully