### PR TITLE
Fix README and template typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ in Twig Templates and Element API.
 {# Expects an Element; Returns an array of Elements. #}
 {% set relations = elementRelationsGetRelations(element) %}
 
-{# Expects an Element; Returns a boolen. #}
+{# Expects an Element; Returns a boolean. #}
 {% set seomaticGlobal = elementRelationsIsUsedInSeomaticGlobalSettings(element) %}
 ```
 

--- a/src/templates/_components/fields/relations.twig
+++ b/src/templates/_components/fields/relations.twig
@@ -1,6 +1,6 @@
-{# Expects an Element; Returns on array of Elements. #}
+{# Expects an Element; Returns an array of Elements. #}
 {% set relations = elementRelationsGetRelations(element) %}
-{# Expects an Elements; Returns a boolen. #}
+{# Expects an Elements; Returns a boolean. #}
 {% set seomaticGlobal = elementRelationsIsUsedInSeomaticGlobalSettings(element) %}
 
 {% if not relations and not seomaticGlobal %}


### PR DESCRIPTION
## Summary
- correct typos in relations field template
- correct typo in README instructions

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861298ff90c8323ba0eb5a808b53064