### PR TITLE
Fix uninitialized property in DatabaseService

### DIFF
--- a/src/services/DatabaseService.php
+++ b/src/services/DatabaseService.php
@@ -6,7 +6,11 @@ use Craft;
 
 class DatabaseService
 {
-    private static bool $isMaria;
+    /**
+     * Cached result of the MariaDB check. `null` indicates it has not been
+     * determined yet.
+     */
+    private static ?bool $isMaria = null;
 
     public static function jsonExtract(string $column, array $path): string
     {
@@ -42,10 +46,13 @@ class DatabaseService
 
     private static function getIsMaria(): bool
     {
-        if (!isset(self::$isMaria)) {
+        if (self::$isMaria === null) {
             $connection = Craft::$app->db;
-            self::$isMaria = $connection->getIsMysql() && str_contains(strtolower($connection->getSchema()->getServerVersion()), 'mariadb');
+            self::$isMaria = $connection->getIsMysql()
+                && str_contains(strtolower($connection->getSchema()->getServerVersion()), 'mariadb');
         }
+
+        // self::$isMaria is guaranteed to be a bool here.
         return self::$isMaria;
     }
 }


### PR DESCRIPTION
## Summary
- prevent fatal error when detecting MariaDB by initializing cached property

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861286f66108323964c7937a5c6c894