### PR TITLE
Fix Asset import for Seomatic check

### DIFF
--- a/src/services/RelationsService.php
+++ b/src/services/RelationsService.php
@@ -7,6 +7,7 @@ use craft\base\ElementInterface;
 use craft\db\Query;
 use craft\db\Table;
 use craft\elements\db\ElementQuery;
+use craft\elements\Asset;
 use craft\models\Site;
 use Illuminate\Support\Collection;
 use internetztube\elementRelations\services\extractors\FieldExtractorCkEditorService;


### PR DESCRIPTION
## Summary
- add missing Asset import in `RelationsService`

## Testing
- `composer validate --no-check-all` *(fails: command not found)*
- `php -l src/services/RelationsService.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612b7582a883238a0b1a4f1b3a813d