### PR TITLE
Add GraphQL support for ElementRelationsField

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,12 @@ As a basis the relations table is used. This means that any field that stores re
 * Hyper
 * LinkIt
 * TypedLinkField
-* Formie  
+* Formie
 ... and many more.
+
+## GraphQL
+The Element Relations field exposes its data in GraphQL. Query the field by its handle to
+access counts, usage flags, and related elements.
 
 ## Usage
 Obtain a `RelationsModel` instance from any element’s relations field, then use its methods to inspect usage.

--- a/src/fields/ElementRelationsField.php
+++ b/src/fields/ElementRelationsField.php
@@ -13,6 +13,9 @@ use craft\helpers\UrlHelper;
 use craft\models\FieldLayoutTab;
 use internetztube\elementRelations\assetbundles\ElementRelationsAsset;
 use internetztube\elementRelations\models\RelationsModel;
+use internetztube\elementRelations\gql\types\Relations as RelationsType;
+use craft\models\GqlSchema;
+use GraphQL\Type\Definition\Type;
 
 class ElementRelationsField extends Field implements PreviewableFieldInterface
 {
@@ -36,6 +39,20 @@ class ElementRelationsField extends Field implements PreviewableFieldInterface
          * to the canonical.
          */
         return new RelationsModel($element->id, $element->siteId);
+    }
+
+    public function includeInGqlSchema(GqlSchema $schema): bool
+    {
+        return true;
+    }
+
+    public function getContentGqlType(): Type|array
+    {
+        return [
+            'name' => $this->handle,
+            'type' => RelationsType::getType(),
+            'resolve' => fn($source) => $source->{$this->handle},
+        ];
     }
 
     /**

--- a/src/gql/types/Relations.php
+++ b/src/gql/types/Relations.php
@@ -1,0 +1,116 @@
+<?php
+namespace internetztube\elementRelations\gql\types;
+
+use Craft;
+use craft\gql\base\ObjectType;
+use craft\gql\base\SingularTypeInterface;
+use craft\gql\GqlEntityRegistry;
+use craft\gql\interfaces\elements\Element as ElementInterface;
+use craft\helpers\Gql as GqlHelper;
+use craft\services\Gql as GqlService;
+use GraphQL\Type\Definition\Type;
+use internetztube\elementRelations\models\RelationsModel;
+
+class Relations extends ObjectType implements SingularTypeInterface
+{
+    public static function getName(): string
+    {
+        return 'ElementRelations';
+    }
+
+    public static function getType(): self
+    {
+        return GqlEntityRegistry::getEntity(self::getName()) ?: GqlEntityRegistry::createEntity(self::getName(), new self([
+            'name' => self::getName(),
+            'fields' => [self::class, 'getFieldDefinitions'],
+        ]));
+    }
+
+    public static function getFieldDefinitions(): array
+    {
+        return Craft::$app->getGql()->prepareFieldDefinitions([
+            'count' => [
+                'name' => 'count',
+                'type' => Type::int(),
+                'args' => [
+                    'siteIds' => [
+                        'name' => 'siteIds',
+                        'type' => Type::listOf(Type::int()),
+                    ],
+                ],
+                'resolve' => function(RelationsModel $source, array $arguments) {
+                    return $source->getCount($arguments['siteIds'] ?? null);
+                },
+            ],
+            'countFast' => [
+                'name' => 'countFast',
+                'type' => Type::int(),
+                'args' => [
+                    'siteIds' => [
+                        'name' => 'siteIds',
+                        'type' => Type::listOf(Type::int()),
+                    ],
+                ],
+                'resolve' => function(RelationsModel $source, array $arguments) {
+                    return $source->getCountFast($arguments['siteIds'] ?? null);
+                },
+            ],
+            'isInUse' => [
+                'name' => 'isInUse',
+                'type' => Type::boolean(),
+                'args' => [
+                    'siteIds' => [
+                        'name' => 'siteIds',
+                        'type' => Type::listOf(Type::int()),
+                    ],
+                ],
+                'resolve' => function(RelationsModel $source, array $arguments) {
+                    return $source->getIsInUse($arguments['siteIds'] ?? null);
+                },
+            ],
+            'isInUseFast' => [
+                'name' => 'isInUseFast',
+                'type' => Type::boolean(),
+                'args' => [
+                    'siteIds' => [
+                        'name' => 'siteIds',
+                        'type' => Type::listOf(Type::int()),
+                    ],
+                ],
+                'resolve' => function(RelationsModel $source, array $arguments) {
+                    return $source->getIsInUseFast($arguments['siteIds'] ?? null);
+                },
+            ],
+            'isUsedInSeomaticGlobalSettings' => [
+                'name' => 'isUsedInSeomaticGlobalSettings',
+                'type' => Type::boolean(),
+                'resolve' => fn(RelationsModel $source) => $source->getIsUsedInSeomaticGlobalSettings(),
+            ],
+            'elements' => [
+                'name' => 'elements',
+                'type' => Type::listOf(ElementInterface::getType()),
+                'args' => [
+                    'siteIds' => [
+                        'name' => 'siteIds',
+                        'type' => Type::listOf(Type::int()),
+                    ],
+                    'limit' => [
+                        'name' => 'limit',
+                        'type' => Type::int(),
+                    ],
+                    'offset' => [
+                        'name' => 'offset',
+                        'type' => Type::int(),
+                    ],
+                ],
+                'resolve' => function(RelationsModel $source, array $arguments) {
+                    $siteIds = $arguments['siteIds'] ?? null;
+                    $limit = $arguments['limit'] ?? null;
+                    $offset = $arguments['offset'] ?? 0;
+                    return $source->getElements($siteIds, $limit, $offset);
+                },
+                'complexity' => GqlHelper::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
+            ],
+        ], self::getName());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ElementRelations` GraphQL type
- expose relations field data to GraphQL
- document GraphQL support in README

## Testing
- `composer dump-autoload -o`
- `php -l src/gql/types/Relations.php`
- `php -l src/fields/ElementRelationsField.php`


------
https://chatgpt.com/codex/tasks/task_e_6883c62b9cf483238206086fb703fb25